### PR TITLE
Add template for connection string formation

### DIFF
--- a/L3_SettingUpMongoAndMongoose/Finished/config/index.js
+++ b/L3_SettingUpMongoAndMongoose/Finished/config/index.js
@@ -3,7 +3,9 @@ var configValues = require('./config');
 module.exports = {
     
     getDbConnectionString: function() {
-        return 'YOUR_MONGO_URL';
-    }
+         return 'mongodb://'
+            + configValues.uname + ':' + configValues.pwd
+            + '@YOUR_MONGO_URL';
+     }
     
 }


### PR DESCRIPTION
`getDbConnectionString` should be concatenated with strings from `configValues` JSON.
Making it to reflect, so there would be no need to return to video to see how exactly that string was made.